### PR TITLE
Prepare for Kodi v20

### DIFF
--- a/api.py
+++ b/api.py
@@ -5,7 +5,7 @@ import sys
 import time
 import requests
 from encrypt import encrypted_request
-from xbmcswift2 import xbmc, xbmcaddon, xbmcplugin
+from xbmcswift2 import xbmc, xbmcaddon, xbmcplugin, xbmcvfs
 from http.cookiejar import Cookie
 from http.cookiejar import MozillaCookieJar
 import re
@@ -14,7 +14,7 @@ DEFAULT_TIMEOUT = 10
 
 BASE_URL = "https://music.163.com"
 
-PROFILE = xbmc.translatePath(xbmcaddon.Addon().getAddonInfo('profile'))
+PROFILE = xbmcvfs.translatePath(xbmcaddon.Addon().getAddonInfo('profile'))
 if not os.path.exists(PROFILE):
     os.makedirs(PROFILE)
 COOKIE_PATH = os.path.join(PROFILE, 'cookie.txt')

--- a/api.py
+++ b/api.py
@@ -14,7 +14,10 @@ DEFAULT_TIMEOUT = 10
 
 BASE_URL = "https://music.163.com"
 
-PROFILE = xbmcvfs.translatePath(xbmcaddon.Addon().getAddonInfo('profile'))
+if sys.version_info.major >= 3:
+    PROFILE = xbmcvfs.translatePath(xbmcaddon.Addon().getAddonInfo('profile'))
+else:
+    PROFILE = xbmc.translatePath(xbmcaddon.Addon().getAddonInfo('profile'))
 if not os.path.exists(PROFILE):
     os.makedirs(PROFILE)
 COOKIE_PATH = os.path.join(PROFILE, 'cookie.txt')


### PR DESCRIPTION
Migrate translatePath function from xbmc.translatePath to xbmcvfs.translatePath.
xbmc.translatePath is deprecated in Kodi v19, and will be removed in Kodi v20.
See [Kodi Development: Library - xbmcvfs](https://xbmc.github.io/docs.kodi.tv/master/kodi-dev-kit/group__python__xbmcvfs.html#ga762f48b2097ec25d938bf8596023b221)